### PR TITLE
Fix unsupported in-app browser

### DIFF
--- a/apps/~internal/lib/UserAgent.ts
+++ b/apps/~internal/lib/UserAgent.ts
@@ -54,9 +54,6 @@ export function isUnsupportedCliBrowser() {
 
 // based on https://github.com/shalanah/inapp-spy/blob/main/src/regexInApp.ts
 const inAppRegExps = [
-  'WebView',
-  '(iPhone|iPod|iPad)(?!.*Safari/)', // Apple devices but not with "Safari/" following
-  'Android.*wv\\)',
   'FB_\\w|FB\\w', // Match Facebook FB_ or FB then word char
   'Snapchat',
   'GSA',


### PR DESCRIPTION
Fix Rabby Wallet's in-app browser unsupported.
<img width="605" height="1280" alt="image" src="https://github.com/user-attachments/assets/73c16bfe-f021-4eb2-978d-d4fd0c52415d" />
